### PR TITLE
Added gitignore to remove .DS_Store from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
added a gitignore file to stop .DS_Store from being tracked. 
.DS_Store is used for file management on Mac so probably useful for y'all as well. 